### PR TITLE
Investigate persistent bot activity bug

### DIFF
--- a/src/routes/bots.js
+++ b/src/routes/bots.js
@@ -80,11 +80,13 @@ router.delete('/:id', async (req, res) => {
   try {
     const botId = req.params.id;
     
+    let success = false;
     if (botManager) {
-      await botManager.stopBot(botId);
+      // Ensure process, in-memory state, DB docs, and files are all cleaned
+      success = await botManager.deleteBot(botId);
+    } else {
+      success = await BotService.deleteBot(botId);
     }
-    
-    const success = await BotService.deleteBot(botId);
     if (!success) {
       return res.status(404).json({ success: false, error: 'Bot not found' });
     }


### PR DESCRIPTION
Rework `stopBot` and integrate `botManager.deleteBot` into the DELETE route to ensure bots reliably stop and are fully cleaned up upon deletion.

The previous `stopBot` logic incorrectly shadowed the global `process` variable and attempted to kill a process group using a negative PID, which often failed silently. Additionally, the DELETE route only removed database entries, leaving the bot's running process, in-memory state, and associated files intact, leading to bots continuing to operate after deletion.

---
<a href="https://cursor.com/background-agent?bcId=bc-04781127-ad86-4a05-ac29-4799f8e9a34d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-04781127-ad86-4a05-ac29-4799f8e9a34d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

